### PR TITLE
Remove string-to-int

### DIFF
--- a/books/interface/emacs/mfm.el
+++ b/books/interface/emacs/mfm.el
@@ -28,7 +28,7 @@
            (stringp emacs-version)
            (< 1 (length emacs-version))
            (string-match "[0-9][0-9]" (substring emacs-version 0 2)))
-      (string-to-int (substring emacs-version 0 2))
+      (string-to-number (substring emacs-version 0 2))
     (error "The file mfm.el works for emacs versions 18 and 19, but not yours.")))
 
 (defvar mfm-comint-p


### PR DESCRIPTION
As `string-to-int` is deleted function in Emacs 26.x, I replaced it with `string-to-number`.
We can use `string-to-number` even before Emacs 26.x. Thus, this request is not a breaking change for users who are using Emacs 25.x .

